### PR TITLE
投稿機能実装（ユーザーあり）

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Things you may want to cover:
 
 
 ## Association
+- belongs_to :user
+- has_many :comment
 
 
 ## userテーブル
@@ -51,6 +53,8 @@ Things you may want to cover:
 
 
 ## Association
+- has_many :prototype
+- has_many :comment
 
 
 ## commentsテーブル
@@ -61,3 +65,7 @@ Things you may want to cover:
 | prototype          | reference    | null: false, foreign_key: true   |
 | user               | reference    | null: false, foreign_key: true   |
 
+
+## Association
+- belongs_to :prototype
+- belongs_to :user

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,5 @@
 class PrototypesController < ApplicationController
-# before_action :move_to_signed_in, expect: [:index, :show]
+before_action :move_to_signed_in, expect: [:index, :show]
 
   def index
     @prototypes = Prototype.all
@@ -26,12 +26,12 @@ class PrototypesController < ApplicationController
   private
 
   def prototype_params
-    params.require(:prototype).permit(:title, :catch_copy, :concept, :image)
+    params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)
   end
 
-  # def move_to_signed_in
-  #   unless user_signed_in?
-  #     redirect_to action: :index
-  #   end
-  # end
+  def move_to_signed_in
+    unless user_signed_in?
+      redirect_to new_user_registration_path
+    end
+  end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -10,11 +10,10 @@ before_action :move_to_signed_in, expect: [:index, :show]
   end
 
   def create
-    prototype = Prototype.create(prototype_params)
-    if prototype.save
+    @prototype = Prototype.new(prototype_params)
+    if @prototype.save
       redirect_to root_path
     else
-      prototype.save
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,4 +1,5 @@
 class Prototype < ApplicationRecord
+  belongs_to :user
   has_one_attached :image
 
   validates :title, :catch_copy, :concept, :image, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :prototype
+  
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :name, presence: true   

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
           <% if user_signed_in? %>
             <div class="nav__right">
                <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: :nav__logout %>
-               <%= link_to "New Proto", root_path, class: :nav__btn %>
+               <%= link_to "New Proto", new_prototype_path, class: :nav__btn %>
             </div> 
 
           <%# // ログインしているときは上記を表示するようにしましょう %>

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -7,9 +7,7 @@
       <p class="card__summary">
         <%= prototype.catch_copy %>
       </p>
-
-      <%# <%= link_to prototype.user, root_path, class: :card__user %> 
-
+      <%= link_to prototype.user.name, root_path, class: :card__user %>
     </div>
   <% end %>
 </div>

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,5 +1,5 @@
 
-<div class="card">
+<div class="card"> 
   <% @prototypes.each do |prototype| %>
     <%= link_to image_tag(prototype.image, class: :card__img), prototype_path(prototype.id) %> 
     <div class="card__body">

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -6,11 +6,10 @@
         こんにちは、
         <%= link_to "#{current_user.name}さん", root_path, class: :greeting__link %>
       </div>
-    <% else %>
+    <% end %>
     <%# // ログインしているときは上記を表示する %>
-    <div class="card__wrapper">
+    <div class="card__wrapper">     
       <%= render "prototype" %>
     </div>
-    <% end %>
   </div>
 </main>

--- a/db/migrate/20240610063231_create_prototypes.rb
+++ b/db/migrate/20240610063231_create_prototypes.rb
@@ -4,6 +4,7 @@ class CreatePrototypes < ActiveRecord::Migration[7.0]
       t.string :title, null: false
       t.text :catch_copy, null: false
       t.text :concept, null: false
+      t.references :user, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,16 @@
-ActiveRecord::Schema[7.0].define(version: 2024_06_10_063231) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
 
+ActiveRecord::Schema[7.0].define(version: 2024_06_10_063231) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -28,13 +39,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_10_063231) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-
   create_table "prototypes", charset: "utf8", force: :cascade do |t|
     t.string "title", null: false
     t.text "catch_copy", null: false
     t.text "concept", null: false
+    t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_prototypes_on_user_id"
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|
@@ -55,4 +67,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_10_063231) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "prototypes", "users"
 end


### PR DESCRIPTION
# What
投稿機能実装

# Why
ユーザー管理機能が完成したので、以下の実装を追加で行いました

ログイン状態の場合のみ、投稿ページへ遷移できること。
ログアウト状態で投稿ページに遷移しようとすると、ログインページに遷移すること。
バリデーションによって投稿ができず、そのページに留まった場合でも、入力済みの項目（画像以外）は消えないこと